### PR TITLE
Fix: use lockfile v2

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,10 +1,11 @@
 {
   "name": "lsp-dockerfile",
   "version": "1.0.0",
-  "lockfileVersion": 3,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "lsp-dockerfile",
       "version": "1.0.0",
       "dependencies": {
         "dockerfile-language-server-nodejs": "^0.14.1"
@@ -123,6 +124,95 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
       "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==",
       "license": "MIT"
+    }
+  },
+  "dependencies": {
+    "dockerfile-ast": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
+      "integrity": "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==",
+      "requires": {
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      }
+    },
+    "dockerfile-language-server-nodejs": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-server-nodejs/-/dockerfile-language-server-nodejs-0.14.1.tgz",
+      "integrity": "sha512-50bvRWmAemwJ9VJD2LIQYiKHyL1pW5WoA1Q7keJ4wT+fCGCVxz59kIJY3GXnnlTSXHh9niv3Wc4pFtmXfmILMg==",
+      "requires": {
+        "dockerfile-language-service": "0.15.1",
+        "dockerfile-utils": "0.16.3",
+        "vscode-languageserver": "~8.0.0",
+        "vscode-languageserver-textdocument": "~1.0.8"
+      }
+    },
+    "dockerfile-language-service": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/dockerfile-language-service/-/dockerfile-language-service-0.15.1.tgz",
+      "integrity": "sha512-0iQBvt/3u8x6ZgYag7QyYPSY2M6Hfn0zB2soywAFZ5THX/13FGk+Vmksqw+a1l+uPDiA+yV7trUedKQ5R0A2aA==",
+      "requires": {
+        "dockerfile-ast": "0.7.1",
+        "dockerfile-utils": "0.16.3",
+        "vscode-languageserver-textdocument": "1.0.8",
+        "vscode-languageserver-types": "3.17.3"
+      },
+      "dependencies": {
+        "vscode-languageserver-textdocument": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+          "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+        }
+      }
+    },
+    "dockerfile-utils": {
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/dockerfile-utils/-/dockerfile-utils-0.16.3.tgz",
+      "integrity": "sha512-BslaqRR6PzCnhu+toDbkVAjq0B0CEgrCltk+enJ/xwCmvAHB1QqpO9QhXVIzMg/iSuD4tzS0Ex9n4Ik5ffI7pA==",
+      "requires": {
+        "dockerfile-ast": "0.7.1",
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      }
+    },
+    "vscode-jsonrpc": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
+    },
+    "vscode-languageserver": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-8.0.2.tgz",
+      "integrity": "sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==",
+      "requires": {
+        "vscode-languageserver-protocol": "3.17.2"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+      "requires": {
+        "vscode-jsonrpc": "8.0.2",
+        "vscode-languageserver-types": "3.17.2"
+      },
+      "dependencies": {
+        "vscode-languageserver-types": {
+          "version": "3.17.2",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+          "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+        }
+      }
+    },
+    "vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+    },
+    "vscode-languageserver-types": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
     }
   }
 }


### PR DESCRIPTION
Yarn fails to install dependencies when using `"lockfileVersion": 3`
Same issue and fix as https://github.com/sublimelsp/LSP-svelte/pull/157